### PR TITLE
Make search strict for better results

### DIFF
--- a/hn_check.rb
+++ b/hn_check.rb
@@ -16,7 +16,7 @@ end
 # Using the HN search API to search for specifc URLs at the command
 # line.
 def search(search_url)
-    params = { :restrictSearchableAttributes => 'url', :query => search_url }
+    params = { :restrictSearchableAttributes => 'url', :query => search_url, :typoTolerance => false }
     hn_search_url = URI('http://hn.algolia.com/api/v1/search')
     hn_search_url.query = URI.encode_www_form(params)
     response = Net::HTTP.get_response(hn_search_url)


### PR DESCRIPTION
**Summary**

This pull request disables fuzzy searching on the URL.

**Description**

The search API is fuzzy per default to deliver results even if there are make typos. This does not work well for URLs using IDs.

Example:

```
$ ruby hn_check.rb https://arxiv.org/abs/1606.04984
found a match at https://news.ycombinator.com/item?id=11929580 created at 2016-06-18T17:24:00.000Z
found a match at https://news.ycombinator.com/item?id=11926943 created at 2016-06-18T03:34:11.000Z
```

I'd expect only the first result, so this PR disables fuzzy searching.
